### PR TITLE
Set path to root in GetArtifactsAsync for iOS implementation. ab#429

### DIFF
--- a/src/Client/App/Platforms/iOS/Implementations/IosFileService.cs
+++ b/src/Client/App/Platforms/iOS/Implementations/IosFileService.cs
@@ -31,6 +31,11 @@ namespace Functionland.FxFiles.Client.App.Platforms.iOS.Implementations
 
         public override IAsyncEnumerable<FsArtifact> GetArtifactsAsync(string? path = null, string? searchText = null, CancellationToken? cancellationToken = null)
         {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                path = "./";
+            }
+
             return base.GetArtifactsAsync(path, searchText, cancellationToken);
         }
 


### PR DESCRIPTION
Set path to root in GetArtifactsAsync for iOS implementation. [AB#340](https://dev.azure.com/Functionland/1ecafc59-99e6-4081-9036-1c592c9f5fd4/_workitems/edit/340)